### PR TITLE
feat(schema)!: kuba.yaml format changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ default:
   project: 1337
 
   # Mapping of cloud projects to environment variables and secret keys.
-  mappings:
+  env:
     - environment-variable: "GCP_PROJECT_ID"
       secret-key: "gcp_project_secret"
     - environment-variable: "AWS_PROJECT_ID"
@@ -253,7 +253,7 @@ development:
   project: 1337
 
   # You can override specific mappings here or add new ones.
-  mappings:
+  env:
     - environment-variable: "DEV_GCP_PROJECT_ID"
       secret-key: "dev_gcp_project_secret"
     - environment-variable: "DEV_AWS_PROJECT_ID"
@@ -267,7 +267,7 @@ staging:
   provider: gcp
   project: 1337
 
-  mappings:
+  env:
     - environment-variable: "STAGING_GCP_PROJECT_ID"
       secret-key: "staging_gcp_project_secret"
     - environment-variable: "STAGING_AWS_PROJECT_ID"
@@ -280,7 +280,7 @@ production:
   provider: gcp
   project: 1337
 
-  mappings:
+  env:
     - environment-variable: "PROD_GCP_PROJECT_ID"
       secret-key: "prod_gcp_project_secret"
     - environment-variable: "PROD_AWS_PROJECT_ID"
@@ -330,7 +330,7 @@ This allows you to:
 default:
   provider: gcp
   project: 1337
-  mappings:
+  env:
     - environment-variable: "DB_PASSWORD"
       secret-key: "db-password"
     - environment-variable: "DB_HOST"
@@ -395,7 +395,7 @@ which is particularly useful for:
 default:
   provider: gcp
   project: 1337
-  mappings:
+  env:
     - environment-variable: "DB"
       secret-path: "database"
     - environment-variable: "API"
@@ -433,7 +433,7 @@ You can also use secret paths with different providers:
 default:
   provider: gcp
   project: 1337
-  mappings:
+  env:
     - environment-variable: "GCP_SECRETS"
       secret-path: "app-config"
       provider: gcp
@@ -504,7 +504,7 @@ Kuba supports GCP Secret Manager for fetching secrets. To use GCP:
    default:
      provider: gcp
      project: 1337
-     mappings:
+     env:
        - environment-variable: "DATABASE_URL"
          secret-key: "database-connection-string"
        - environment-variable: "API_KEY"
@@ -539,7 +539,7 @@ Kuba supports AWS Secrets Manager for fetching secrets. To use AWS:
    ```yaml
    default:
      provider: aws
-     mappings:
+     env:
        - environment-variable: "DATABASE_URL"
          secret-key: "database-connection-string"
        - environment-variable: "API_KEY"
@@ -569,7 +569,7 @@ Kuba supports Azure Key Vault for fetching secrets. To use Azure Key Vault:
    ```yaml
    default:
      provider: azure
-     mappings:
+     env:
        - environment-variable: "DATABASE_URL"
          secret-key: "database-connection-string"
        - environment-variable: "SOME_HARD_CODED_ENV"
@@ -598,7 +598,7 @@ To use OpenBao:
    ```yaml
    default:
      provider: openbao
-     mappings:
+     env:
        - environment-variable: "DATABASE_URL"
          secret-key: "secret/database-url"
        - environment-variable: "API_KEY"
@@ -612,7 +612,7 @@ To use OpenBao:
 ```yaml
 default:
   provider: openbao
-  mappings:
+  env:
     - environment-variable: "DATABASE_URL"
       secret-key: "database-url"
       project: "secret"  # This will look for secret/database-url

--- a/cmd/kuba/run.go
+++ b/cmd/kuba/run.go
@@ -80,7 +80,7 @@ func runCommand(args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to get environment '%s': %w", environment, err)
 	}
-	logger.Debug("Environment configuration retrieved", "environment", environment, "provider", env.Provider, "mappings_count", len(env.Mappings))
+	logger.Debug("Environment configuration retrieved", "environment", environment, "provider", env.Provider, "env_count", len(env.Env))
 
 	// Create secrets manager factory
 	logger.Debug("Creating secrets manager factory")

--- a/internal/lib/secrets/local.go
+++ b/internal/lib/secrets/local.go
@@ -1,0 +1,88 @@
+package secrets
+
+import (
+	"context"
+	"fmt"
+	"os"
+)
+
+// LocalManager implements SecretManager for local environment variables
+type LocalManager struct {
+	ctx context.Context
+}
+
+// NewLocalManager creates a new local secret manager
+func NewLocalManager(ctx context.Context) (SecretManager, error) {
+	return &LocalManager{
+		ctx: ctx,
+	}, nil
+}
+
+// GetSecret retrieves a single secret from environment variables
+func (l *LocalManager) GetSecret(projectID, secretID string) (string, error) {
+	// For local provider, we just return the environment variable value
+	value := os.Getenv(secretID)
+	if value == "" {
+		return "", fmt.Errorf("environment variable '%s' not found", secretID)
+	}
+	return value, nil
+}
+
+// GetSecrets retrieves multiple secrets from environment variables
+func (l *LocalManager) GetSecrets(projectID string, secretIDs []string) (map[string]string, error) {
+	secrets := make(map[string]string)
+
+	for _, secretID := range secretIDs {
+		value := os.Getenv(secretID)
+		if value != "" {
+			secrets[secretID] = value
+		}
+		// Note: We don't return an error if a secret is not found,
+		// we just skip it to be consistent with other providers
+	}
+
+	return secrets, nil
+}
+
+// GetSecretsByPath retrieves all environment variables that start with the given path
+func (l *LocalManager) GetSecretsByPath(projectID, secretPath string) (map[string]string, error) {
+	secrets := make(map[string]string)
+
+	// Get all environment variables
+	for _, env := range os.Environ() {
+		// Split on first '=' to get key and value
+		parts := splitEnvVar(env)
+		if len(parts) == 2 {
+			key := parts[0]
+			value := parts[1]
+
+			// Check if this environment variable starts with our path
+			if len(key) >= len(secretPath) && key[:len(secretPath)] == secretPath {
+				// Remove the path prefix from the key
+				secretName := key[len(secretPath):]
+				// Remove leading underscore if present
+				if len(secretName) > 0 && secretName[0] == '_' {
+					secretName = secretName[1:]
+				}
+				secrets[secretName] = value
+			}
+		}
+	}
+
+	return secrets, nil
+}
+
+// Close closes the local manager (no-op for local provider)
+func (l *LocalManager) Close() error {
+	return nil
+}
+
+// splitEnvVar splits an environment variable string on the first '=' character
+func splitEnvVar(env string) []string {
+	for i, char := range env {
+		if char == '=' {
+			return []string{env[:i], env[i+1:]}
+		}
+	}
+	return []string{env}
+}

--- a/internal/lib/secrets/manager.go
+++ b/internal/lib/secrets/manager.go
@@ -63,6 +63,9 @@ func (f *SecretManagerFactory) CreateSecretManager(ctx context.Context, provider
 		namespace := os.Getenv("OPENBAO_NAMESPACE")
 
 		return NewOpenBaoManager(ctx, address, token, namespace)
+	case "local":
+		// Local provider doesn't require any external configuration
+		return NewLocalManager(ctx)
 	default:
 		return nil, fmt.Errorf("unsupported cloud provider: %s", provider)
 	}
@@ -78,69 +81,71 @@ func (f *SecretManagerFactory) GetSecretsForEnvironment(ctx context.Context, env
 	// Group mappings by provider and project for path-based mappings
 	pathGroups := make(map[string]map[string]string)
 
-	logger.Debug("Processing environment mappings", "total_mappings", len(env.Mappings))
+	// Get all env items (from map)
+	envItems := env.GetEnvItems()
+	logger.Debug("Processing environment mappings", "total_mappings", len(envItems))
 
-	// Process all mappings to separate secret-based and value-based ones
-	for i, mapping := range env.Mappings {
-		logger.Debug("Processing mapping", "index", i, "env_var", mapping.EnvironmentVariable, "has_secret_key", mapping.SecretKey != "", "has_secret_path", mapping.SecretPath != "", "has_value", mapping.Value != nil)
+	// Process all env items to separate secret-based and value-based ones
+	for i, envItem := range envItems {
+		logger.Debug("Processing mapping", "index", i, "env_var", envItem.EnvironmentVariable, "has_secret_key", envItem.SecretKey != "", "has_secret_path", envItem.SecretPath != "", "has_value", envItem.Value != nil)
 
 		// Handle direct values first
-		if mapping.Value != nil {
-			logger.Debug("Skipping secret processing for value-based mapping", "env_var", mapping.EnvironmentVariable)
+		if envItem.Value != nil {
+			logger.Debug("Skipping secret processing for value-based mapping", "env_var", envItem.EnvironmentVariable)
 			continue // Skip secret processing for value-based mappings
 		}
 
 		// Process secret-based mappings (single key)
-		if mapping.SecretKey != "" {
-			provider := mapping.Provider
+		if envItem.SecretKey != "" {
+			provider := envItem.Provider
 			if provider == "" {
 				provider = env.Provider
 			}
 
-			project := mapping.Project
+			project := envItem.Project
 			if project == "" {
 				project = env.Project
 			}
 
-			// For AWS, Azure, and OpenBao, we use a default project key since they don't use projects in the same way as GCP
-			if (provider == "aws" || provider == "azure" || provider == "openbao") && project == "" {
+			// For AWS, Azure, OpenBao, and local, we use a default project key since they don't use projects in the same way as GCP
+			if (provider == "aws" || provider == "azure" || provider == "openbao" || provider == "local") && project == "" {
 				project = "default"
 			}
 
-			logger.Debug("Adding secret-based mapping to provider group", "provider", provider, "project", project, "secret_key", mapping.SecretKey)
+			logger.Debug("Adding secret-based mapping to provider group", "provider", provider, "project", project, "secret_key", envItem.SecretKey)
 
 			if providerGroups[provider] == nil {
 				providerGroups[provider] = make(map[string][]string)
 			}
 
-			providerGroups[provider][project] = append(providerGroups[provider][project], mapping.SecretKey)
+			providerGroups[provider][project] = append(providerGroups[provider][project], envItem.SecretKey)
 		}
 
 		// Process path-based mappings
-		if mapping.SecretPath != "" {
-			provider := mapping.Provider
+		if envItem.SecretPath != "" {
+			provider := envItem.Provider
 			if provider == "" {
 				provider = env.Provider
 			}
 
-			project := mapping.Project
+			project := envItem.Project
 			if project == "" {
 				project = env.Project
 			}
 
-			// For AWS, Azure, and OpenBao, we use a default project key since they don't use projects in the same way as GCP
-			if (provider == "aws" || provider == "azure" || provider == "openbao") && project == "" {
+			// For AWS, Azure, OpenBao, and local, we use a default project key since they don't use projects in the same way as GCP
+			if (provider == "aws" || provider == "azure" || provider == "openbao" || provider == "local") && project == "" {
 				project = "default"
 			}
 
-			logger.Debug("Adding path-based mapping to provider group", "provider", provider, "project", project, "secret_path", mapping.SecretPath)
+			logger.Debug("Adding path-based mapping to provider group", "provider", provider, "project", project, "secret_path", envItem.SecretPath)
 
 			// Create a separate group for path-based lookups
 			pathKey := fmt.Sprintf("%s:%s", provider, project)
 			if pathGroups[pathKey] == nil {
 				pathGroups[pathKey] = make(map[string]string)
 			}
-			pathGroups[pathKey][mapping.EnvironmentVariable] = mapping.SecretPath
+			pathGroups[pathKey][envItem.EnvironmentVariable] = envItem.SecretPath
 		}
 	}
 
@@ -174,30 +179,30 @@ func (f *SecretManagerFactory) GetSecretsForEnvironment(ctx context.Context, env
 			logger.Debug("Successfully retrieved secrets from provider", "provider", provider, "project", project, "retrieved_count", len(secrets))
 
 			// Map secrets to environment variables
-			for _, mapping := range env.Mappings {
-				if mapping.SecretKey != "" {
-					mappingProvider := mapping.Provider
-					if mappingProvider == "" {
-						mappingProvider = env.Provider
+			for _, envItem := range envItems {
+				if envItem.SecretKey != "" {
+					envItemProvider := envItem.Provider
+					if envItemProvider == "" {
+						envItemProvider = env.Provider
 					}
 
-					mappingProject := mapping.Project
-					if mappingProject == "" {
-						mappingProject = env.Project
+					envItemProject := envItem.Project
+					if envItemProject == "" {
+						envItemProject = env.Project
 					}
 
-					// For AWS, Azure, and OpenBao, we use a default project key since they don't use projects in the same way as GCP
-					if (mappingProvider == "aws" || mappingProvider == "azure" || mappingProvider == "openbao") && mappingProject == "" {
-						mappingProject = "default"
+					// For AWS, Azure, OpenBao, and local, we use a default project key since they don't use projects in the same way as GCP
+					if (envItemProvider == "aws" || envItemProvider == "azure" || envItemProvider == "openbao" || envItemProvider == "local") && envItemProject == "" {
+						envItemProject = "default"
 					}
 
 					// Only process mappings that match the current provider and project
-					if mappingProvider == provider && mappingProject == project {
-						if secretValue, exists := secrets[mapping.SecretKey]; exists {
-							allSecrets[mapping.EnvironmentVariable] = secretValue
-							logger.Debug("Mapped secret to environment variable", "env_var", mapping.EnvironmentVariable, "secret_key", mapping.SecretKey, "provider", provider, "project", project)
+					if envItemProvider == provider && envItemProject == project {
+						if secretValue, exists := secrets[envItem.SecretKey]; exists {
+							allSecrets[envItem.EnvironmentVariable] = secretValue
+							logger.Debug("Mapped secret to environment variable", "env_var", envItem.EnvironmentVariable, "secret_key", envItem.SecretKey, "provider", provider, "project", project)
 						} else {
-							logger.Debug("Secret key not found in provider response", "env_var", mapping.EnvironmentVariable, "secret_key", mapping.SecretKey, "provider", provider, "project", project)
+							logger.Debug("Secret key not found in provider response", "env_var", envItem.EnvironmentVariable, "secret_key", envItem.SecretKey, "provider", provider, "project", project)
 						}
 					}
 				}
@@ -244,12 +249,12 @@ func (f *SecretManagerFactory) GetSecretsForEnvironment(ctx context.Context, env
 		}
 	}
 
-	// Process value-based mappings
-	for _, mapping := range env.Mappings {
-		if mapping.Value != nil {
+	// Process value-based mappings (no bare items allowed anymore)
+	for _, envItem := range envItems {
+		if envItem.Value != nil {
 			// Convert value to string
 			var strValue string
-			switch v := mapping.Value.(type) {
+			switch v := envItem.Value.(type) {
 			case string:
 				strValue = v
 			case int, int32, int64:
@@ -259,7 +264,7 @@ func (f *SecretManagerFactory) GetSecretsForEnvironment(ctx context.Context, env
 			default:
 				strValue = fmt.Sprintf("%v", v)
 			}
-			allSecrets[mapping.EnvironmentVariable] = strValue
+			allSecrets[envItem.EnvironmentVariable] = strValue
 		}
 	}
 

--- a/kuba.schema.json
+++ b/kuba.schema.json
@@ -15,7 +15,8 @@
             "gcp",
             "azure",
             "aws",
-            "openbao"
+            "openbao",
+            "local"
           ]
         },
         "project": {
@@ -25,78 +26,44 @@
             "integer"
           ]
         },
-        "mappings": {
-          "description": "A list of environment variable to secret key or value mappings.",
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "environment-variable": {
-                "description": "The name of the environment variable.",
-                "type": "string"
+        "env": {
+          "description": "Mapping of environment variable name to configuration object.",
+          "type": "object",
+          "patternProperties": {
+            "^[A-Z0-9_]+$": {
+              "type": "object",
+              "properties": {
+                "secret-key": { "type": "string" },
+                "secret-path": { "type": "string" },
+                "value": { "type": ["string","integer"] },
+                "provider": { "type": "string", "enum": ["gcp","azure","aws","openbao","local"] },
+                "project": { "type": ["string","integer"] }
               },
-              "secret-key": {
-                "description": "The name of the secret key. Required if no value is provided.",
-                "type": "string"
-              },
-              "secret-path": {
-                "description": "The path prefix to lookup all secrets starting with this string. Required if no secret-key or value is provided.",
-                "type": "string"
-              },
-              "value": {
-                "description": "The literal value for the environment variable. Required if no secret-key is provided. Supports environment variable interpolation using ${VAR_NAME} syntax, which can reference previously defined environment variables from the same configuration or system environment variables.",
-                "type": [
-                  "string",
-                  "integer"
-                ]
-              },
-              "provider": {
-                "description": "Optional override for the cloud provider.",
-                "type": "string",
-                "enum": [
-                  "gcp",
-                  "azure",
-                  "aws",
-                  "openbao"
-                ]
-              },
-              "project": {
-                "description": "Optional override for the cloud project.",
-                "type": [
-                  "string",
-                  "integer"
-                ]
-              }
-            },
-            "required": [
-              "environment-variable"
-            ],
-            "oneOf": [
-              {
-                "required": [
-                  "secret-key"
-                ]
-              },
-              {
-                "required": [
-                  "secret-path"
-                ]
-              },
-              {
-                "required": [
-                  "value"
-                ]
-              }
-            ],
-            "additionalProperties": false
-          }
+              "oneOf": [
+                { "required": [ "secret-key" ] },
+                { "required": [ "secret-path" ] },
+                { "required": [ "value" ] }
+              ],
+              "allOf": [
+                {
+                  "if": { "properties": { "provider": { "const": "local" } } },
+                  "then": {
+                    "required": [ "value" ],
+                    "not": { "anyOf": [ { "required": ["secret-key"] }, { "required": ["secret-path"] } ] }
+                  }
+                }
+              ],
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
         }
       },
       "allOf": [
         {
           "required": [
             "provider",
-            "mappings"
+            "env"
           ]
         },
         {
@@ -104,7 +71,7 @@
             "properties": {
               "provider": {
                 "not": {
-                  "enum": ["aws", "azure", "openbao"]
+                  "enum": ["aws", "azure", "openbao", "local"]
                 }
               }
             }

--- a/web/src/routes/configuration/+page.svelte
+++ b/web/src/routes/configuration/+page.svelte
@@ -85,7 +85,7 @@
 						<h3 class="card-title">Basic Structure</h3>
 						<p class="mb-4">
 							The <code>kuba.yaml</code> file is organized into environment sections, each with its own
-							provider and mappings:
+							provider and env:
 						</p>
 						<pre><code
 								class="language-yaml"
@@ -96,24 +96,24 @@
 default:
   provider: gcp
   project: 1337
-  mappings:
-    - environment-variable: "DATABASE_URL"
+  env:
+    DATABASE_URL:
       secret-key: "database-connection-string"
-    - environment-variable: "API_KEY"
+    API_KEY:
       secret-key: "external-api-key"
 
 development:
   provider: gcp
   project: 1337
-  mappings:
-    - environment-variable: "DEV_DATABASE_URL"
+  env:
+    DEV_DATABASE_URL:
       secret-key: "dev-database-connection-string"
 
 production:
   provider: gcp
   project: 1337
-  mappings:
-    - environment-variable: "PROD_DATABASE_URL"
+  env:
+    PROD_DATABASE_URL:
       secret-key: "prod-database-connection-string"</code
 							></pre>
 					</div>
@@ -175,10 +175,10 @@ production:
 									class="language-yaml"
 									data-toolbar-order="copy-to-clipboard"
 									data-prismjs-copy="📋"
-									>mappings:
-  - environment-variable: "DATABASE_URL"
+									>env:
+  DATABASE_URL:
     secret-key: "database-connection-string"
-  - environment-variable: "API_KEY"
+  API_KEY:
     secret-key: "external-api-key"</code
 								></pre>
 						</div>
@@ -192,10 +192,10 @@ production:
 									class="language-yaml"
 									data-toolbar-order="copy-to-clipboard"
 									data-prismjs-copy="📋"
-									>mappings:
-  - environment-variable: "DB"
+									>env:
+  DB:
     secret-path: "database"
-  - environment-variable: "API"
+  API:
     secret-path: "external-apis"</code
 								></pre>
 							<p class="mt-4 text-sm">
@@ -213,10 +213,10 @@ production:
 									class="language-yaml"
 									data-toolbar-order="copy-to-clipboard"
 									data-prismjs-copy="📋"
-									>mappings:
-  - environment-variable: "APP_ENV"
+									>env:
+  APP_ENV:
     value: "production"
-  - environment-variable: "DEBUG"
+  DEBUG:
     value: "false"</code
 								></pre>
 						</div>
@@ -243,12 +243,12 @@ production:
 								class="language-yaml"
 								data-toolbar-order="copy-to-clipboard"
 								data-prismjs-copy="📋"
-								>mappings:
-  - environment-variable: "DB_PASSWORD"
+								>env:
+  DB_PASSWORD:
     secret-key: "db-password"
-  - environment-variable: "DB_HOST"
+  DB_HOST:
     value: "mydbhost"
-  - environment-variable: "DB_CONNECTION_STRING"
+  DB_CONNECTION_STRING:
     value: "postgresql://user:$&lbrace;DB_PASSWORD&rbrace;@$&lbrace;DB_HOST&rbrace;:5432/mydb"</code
 							></pre>
 					</div>
@@ -263,7 +263,7 @@ production:
 									class="language-yaml"
 									data-toolbar-order="copy-to-clipboard"
 									data-prismjs-copy="📋"
-									>- environment-variable: "API_URL"
+									>API_URL:
   value: "https://api.$&lbrace;DOMAIN&rbrace;/v1"</code
 								></pre>
 						</div>
@@ -277,7 +277,7 @@ production:
 									class="language-yaml"
 									data-toolbar-order="copy-to-clipboard"
 									data-prismjs-copy="📋"
-									>- environment-variable: "REDIS_URL"
+									>REDIS_URL:
   value: "redis://$&lbrace;REDIS_HOST:-localhost&rbrace;:$&lbrace;REDIS_PORT:-6379&rbrace;/0"</code
 								></pre>
 						</div>
@@ -325,13 +325,13 @@ production:
 								>default:
   provider: gcp
   project: 1337
-  mappings:
-    - environment-variable: "GCP_PROJECT_ID"
+  env:
+    GCP_PROJECT_ID:
       secret-key: "gcp_project_secret"
-    - environment-variable: "AWS_PROJECT_ID"
+    AWS_PROJECT_ID:
       secret-key: "aws_project_secret"
       provider: aws
-    - environment-variable: "AZURE_PROJECT_ID"
+    AZURE_PROJECT_ID:
       secret-key: "azure_project_secret"
       provider: azure
       project: "my-azure-project"</code
@@ -358,60 +358,60 @@ production:
 default:
   provider: gcp
   project: 1337
-  mappings:
+  env:
     # Individual secrets
-    - environment-variable: "DATABASE_URL"
+    DATABASE_URL:
       secret-key: "database-connection-string"
-    - environment-variable: "STRIPE_API_KEY"
+    STRIPE_API_KEY:
       secret-key: "stripe-api-key"
 
     # Secret paths for bulk loading
-    - environment-variable: "DB"
+    DB:
       secret-path: "database"
-    - environment-variable: "API"
+    API:
       secret-path: "external-apis"
 
     # Hard-coded values
-    - environment-variable: "APP_ENV"
+    APP_ENV:
       value: "development"
-    - environment-variable: "DEBUG"
+    DEBUG:
       value: "true"
 
     # Interpolated values
-    - environment-variable: "REDIS_URL"
+    REDIS_URL:
       value: "redis://$&lbrace;REDIS_HOST:-localhost$&rbrace;:$&lbrace;REDIS_PORT:-6379&rbrace;/0"
-    - environment-variable: "LOG_LEVEL"
+    LOG_LEVEL:
       value: "$&lbrace;LOG_LEVEL:-info&rbrace;"
 
 development:
   provider: gcp
   project: 1337
-  mappings:
-    - environment-variable: "DEV_DATABASE_URL"
+  env:
+    DEV_DATABASE_URL:
       secret-key: "dev-database-connection-string"
-    - environment-variable: "DEV_STRIPE_API_KEY"
+    DEV_STRIPE_API_KEY:
       secret-key: "dev-stripe-api-key"
 
 staging:
   provider: gcp
   project: 1337
-  mappings:
-    - environment-variable: "STAGING_DATABASE_URL"
+  env:
+    STAGING_DATABASE_URL:
       secret-key: "staging-database-connection-string"
-    - environment-variable: "STAGING_STRIPE_API_KEY"
+    STAGING_STRIPE_API_KEY:
       secret-key: "staging-stripe-api-key"
 
 production:
   provider: gcp
   project: 1337
-  mappings:
-    - environment-variable: "PROD_DATABASE_URL"
+  env:
+    PROD_DATABASE_URL:
       secret-key: "prod-database-connection-string"
-    - environment-variable: "PROD_STRIPE_API_KEY"
+    PROD_STRIPE_API_KEY:
       secret-key: "prod-stripe-api-key"
-    - environment-variable: "APP_ENV"
+    APP_ENV:
       value: "production"
-    - environment-variable: "DEBUG"
+    DEBUG:
       value: "false"</code
 							></pre>
 					</div>

--- a/web/src/routes/examples/+page.svelte
+++ b/web/src/routes/examples/+page.svelte
@@ -85,14 +85,14 @@
 									>production:
   provider: gcp
   project: 1337
-  mappings:
-    - environment-variable: "DATABASE_URL"
+  env:
+    DATABASE_URL:
       secret-key: "prod-database-url"
-    - environment-variable: "JWT_SECRET"
+    JWT_SECRET:
       secret-key: "jwt-secret"
-    - environment-variable: "STRIPE_SECRET_KEY"
+    STRIPE_SECRET_KEY:
       secret-key: "stripe-secret-key"
-    - environment-variable: "REDIS_URL"
+    REDIS_URL:
       value: "redis://$&lbrace;REDIS_HOST:-localhost&rbrace;:6379"</code
 								></pre>
 
@@ -148,14 +148,14 @@ app.listen(3000, () => &lbrace;
 									data-prismjs-copy="📋"
 									>development:
   provider: aws
-  mappings:
-    - environment-variable: "FLASK_ENV"
+  env:
+    FLASK_ENV:
       value: "development"
-    - environment-variable: "DATABASE_URL"
+    DATABASE_URL:
       secret-key: "dev-database-url"
-    - environment-variable: "SECRET_KEY"
+    SECRET_KEY:
       secret-key: "flask-secret-key"
-    - environment-variable: "DEBUG"
+    DEBUG:
       value: "true"</code
 								></pre>
 
@@ -227,18 +227,18 @@ kuba run --env development -- npm run seed</code
 									>production:
   provider: gcp
   project: 1337
-  mappings:
-    - environment-variable: "DATABASE_URL"
+  env:
+    DATABASE_URL:
       secret-key: "prod-postgres-url"
-    - environment-variable: "DB_PASSWORD"
+    DB_PASSWORD:
       secret-key: "prod-db-password"
 
 development:
   provider: aws
-  mappings:
-    - environment-variable: "DATABASE_URL"
+  env:
+    DATABASE_URL:
       secret-key: "dev-postgres-url"
-    - environment-variable: "DB_PASSWORD"
+    DB_PASSWORD:
       secret-key: "dev-db-password"</code
 								></pre>
 						</div>
@@ -268,14 +268,14 @@ development:
 									data-prismjs-copy="📋"
 									>staging:
   provider: azure
-  mappings:
-    - environment-variable: "STRIPE_API_KEY"
+  env:
+    STRIPE_API_KEY:
       secret-key: "stripe-staging-key"
-    - environment-variable: "SENDGRID_API_KEY"
+    SENDGRID_API_KEY:
       secret-key: "sendgrid-staging-key"
-    - environment-variable: "TWILIO_ACCOUNT_SID"
+    TWILIO_ACCOUNT_SID:
       secret-key: "twilio-account-sid"
-    - environment-variable: "TWILIO_AUTH_TOKEN"
+    TWILIO_AUTH_TOKEN:
       secret-key: "twilio-auth-token"</code
 								></pre>
 
@@ -586,25 +586,25 @@ kuba run --env development -- npm run start:services</code
 									>development:
   provider: gcp
   project: 1337
-  mappings:
-    - environment-variable: "DATABASE_URL"
+  env:
+    DATABASE_URL:
       secret-key: "dev-database-url"
-    - environment-variable: "API_KEY"
+    API_KEY:
       secret-key: "dev-api-key"
-    - environment-variable: "DEBUG"
+    DEBUG:
       value: "true"
-    - environment-variable: "LOG_LEVEL"
+    LOG_LEVEL:
       value: "debug"
 
 testing:
   provider: gcp
   project: 1337
-  mappings:
-    - environment-variable: "DATABASE_URL"
+  env:
+    DATABASE_URL:
       secret-key: "test-database-url"
-    - environment-variable: "API_KEY"
+    API_KEY:
       secret-key: "test-api-key"
-    - environment-variable: "NODE_ENV"
+    NODE_ENV:
       value: "test"</code
 								></pre>
 						</div>
@@ -624,21 +624,21 @@ testing:
 default:
   provider: gcp
   project: 1337
-  mappings:
-    - environment-variable: "DATABASE_URL"
+  env:
+    DATABASE_URL:
       secret-key: "database-url"
-    - environment-variable: "API_KEY"
+    API_KEY:
       secret-key: "api-key"
-    - environment-variable: "REDIS_URL"
+    REDIS_URL:
       value: "redis://$&lbrace;REDIS_HOST:-localhost&rbrace;:6379"
 
 development:
   provider: gcp
   project: 1337
-  mappings:
-    - environment-variable: "DATABASE_URL"
+  env:
+    DATABASE_URL:
       secret-key: "dev-database-url"
-    - environment-variable: "DEBUG"
+    DEBUG:
       value: "true"</code
 								></pre>
 
@@ -676,28 +676,28 @@ development:
 									>production:
   provider: gcp
   project: 1337
-  mappings:
+  env:
     # Individual secrets
-    - environment-variable: "APP_ENV"
+    APP_ENV:
       value: "production"
 
     # Database secrets (bulk load)
-    - environment-variable: "DB"
+    DB:
       secret-path: "database"
 
     # API keys (bulk load)
-    - environment-variable: "API"
+    API:
       secret-path: "external-apis"
 
     # Service secrets (bulk load)
-    - environment-variable: "SERVICE"
+    SERVICE:
       secret-path: "microservices"
 
     # Interpolated connection strings
-    - environment-variable: "DATABASE_URL"
+    DATABASE_URL:
       value: "postgresql://$&lbrace;DB_USERNAME&rbrace;:$&lbrace;DB_PASSWORD&rbrace;@$&lbrace;DB_HOST&rbrace;:$&lbrace;DB_PORT&rbrace;/$&lbrace;DB_NAME&rbrace;"
 
-    - environment-variable: "REDIS_URL"
+    REDIS_URL:
       value: "redis://$&lbrace;REDIS_HOST:-localhost&rbrace;:$&lbrace;REDIS_PORT:-6379&rbrace;/0"</code
 								></pre>
 
@@ -722,31 +722,31 @@ development:
 									>production:
   provider: gcp
   project: 1337
-  mappings:
+  env:
     # GCP secrets
-    - environment-variable: "GCP_PROJECT_ID"
+    GCP_PROJECT_ID:
       secret-key: "project-id"
 
     # AWS secrets
-    - environment-variable: "AWS_ACCESS_KEY"
+    AWS_ACCESS_KEY:
       secret-key: "aws-access-key"
       provider: aws
 
     # Azure secrets
-    - environment-variable: "AZURE_TENANT_ID"
+    AZURE_TENANT_ID:
       secret-key: "tenant-id"
       provider: azure
       project: "my-azure-project"
 
     # OpenBao secrets
-    - environment-variable: "INTERNAL_API_KEY"
+    INTERNAL_API_KEY:
       secret-key: "internal-api-key"
       provider: openbao
 
     # Hard-coded values
-    - environment-variable: "APP_ENV"
+    APP_ENV:
       value: "production"
-    - environment-variable: "DEBUG"
+    DEBUG:
       value: "false"</code
 								></pre>
 						</div>

--- a/web/src/routes/providers/+page.svelte
+++ b/web/src/routes/providers/+page.svelte
@@ -180,10 +180,10 @@
 									>default:
   provider: gcp
   project: your-project-id
-  mappings:
-    - environment-variable: "DATABASE_URL"
+  env:
+    DATABASE_URL:
       secret-key: "database-connection-string"
-    - environment-variable: "API_KEY"
+    API_KEY:
       secret-key: "external-api-key"</code
 								></pre>
 						</div>
@@ -272,10 +272,10 @@ export AWS_REGION="us-east-1"</code
 									data-prismjs-copy="📋"
 									>default:
   provider: aws
-  mappings:
-    - environment-variable: "DATABASE_URL"
+  env:
+    DATABASE_URL:
       secret-key: "database-connection-string"
-    - environment-variable: "API_KEY"
+    API_KEY:
       secret-key: "external-api-key"</code
 								></pre>
 						</div>
@@ -339,10 +339,10 @@ export AZURE_CLIENT_SECRET="your-client-secret"</code
 									data-prismjs-copy="📋"
 									>default:
   provider: azure
-  mappings:
-    - environment-variable: "DATABASE_URL"
+  env:
+    DATABASE_URL:
       secret-key: "database-connection-string"
-    - environment-variable: "API_KEY"
+    API_KEY:
       secret-key: "external-api-key"</code
 								></pre>
 						</div>
@@ -396,10 +396,10 @@ export OPENBAO_NAMESPACE="your-namespace"     # Optional: Namespace (if using en
 									data-prismjs-copy="📋"
 									>default:
   provider: openbao
-  mappings:
-    - environment-variable: "DATABASE_URL"
+  env:
+    DATABASE_URL:
       secret-key: "secret/database-url"
-    - environment-variable: "API_KEY"
+    API_KEY:
       secret-key: "secret/api-key"</code
 								></pre>
 							<p class="mt-4 text-sm">
@@ -425,18 +425,18 @@ export OPENBAO_NAMESPACE="your-namespace"     # Optional: Namespace (if using en
 								>default:
   provider: gcp
   project: 1337
-  mappings:
-    - environment-variable: "GCP_SECRETS"
+  env:
+    GCP_SECRETS:
       secret-path: "app-config"
       provider: gcp
-    - environment-variable: "AWS_SECRETS"
+    AWS_SECRETS:
       secret-path: "app-config"
       provider: aws
-    - environment-variable: "AZURE_SECRETS"
+    AZURE_SECRETS:
       secret-path: "app-config"
       provider: azure
       project: "my-azure-project"
-    - environment-variable: "OPENBAO_SECRETS"
+    OPENBAO_SECRETS:
       secret-path: "app-config"
       provider: openbao</code
 							></pre>


### PR DESCRIPTION
BREAKING CHANGE

Old syntax was:

```yaml
mappings:
  - environment-variable: "FOO"
    value: "BAR"
```

New syntax is:

```yaml
env:
  FOO:
    value: "BAR"
```

The reasoning behind this is to make the config less verbose and easier to read.

As long as you don't want or can upgrade your configuration files, use the release v0.8.0 which still supports the old configuration format.