### PR TITLE
feat(config): add inherits from env block

### DIFF
--- a/.github/workflows/web.yaml
+++ b/.github/workflows/web.yaml
@@ -7,8 +7,8 @@ on:
       - '.github/workflows/web.yaml'
       - 'web/**'
       - 'kuba.schema.json'
-    branches:
-      - main
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/internal/config/kuba_config.go
+++ b/internal/config/kuba_config.go
@@ -21,18 +21,61 @@ type Environment struct {
 	Provider string             `yaml:"provider"`
 	Project  string             `yaml:"project"`
 	Env      map[string]EnvItem `yaml:"env"`
+	Inherits []string           `yaml:"inherits,omitempty"`
+}
+
+// UnmarshalYAML implements custom YAML unmarshaling for Environment to support
+// inherits provided as either a single string or a list of strings.
+func (e *Environment) UnmarshalYAML(value *yaml.Node) error {
+	type rawEnv struct {
+		Provider string             `yaml:"provider"`
+		Project  string             `yaml:"project"`
+		Env      map[string]EnvItem `yaml:"env"`
+		Inherits interface{}        `yaml:"inherits,omitempty"`
+	}
+	var tmp rawEnv
+	if err := value.Decode(&tmp); err != nil {
+		return err
+	}
+	e.Provider = tmp.Provider
+	e.Project = tmp.Project
+	e.Env = tmp.Env
+
+	// Normalize inherits to []string
+	e.Inherits = nil
+	switch v := tmp.Inherits.(type) {
+	case nil:
+		// nothing
+	case string:
+		if v != "" {
+			e.Inherits = []string{v}
+		}
+	case []interface{}:
+		list := make([]string, 0, len(v))
+		for _, item := range v {
+			if s, ok := item.(string); ok && s != "" {
+				list = append(list, s)
+			}
+		}
+		if len(list) > 0 {
+			e.Inherits = list
+		}
+	default:
+		return fmt.Errorf("invalid type for inherits: %T", v)
+	}
+	return nil
 }
 
 // EnvItem represents an environment variable configuration in the new simplified format
 // It can be either a string (just the env var name) or a full mapping object
 type EnvItem struct {
 	// For string format: just the environment variable name
-	EnvironmentVariable string      `yaml:"environment-variable,omitempty"`
-	SecretKey           string      `yaml:"secret-key,omitempty"`
-	SecretPath          string      `yaml:"secret-path,omitempty"`
-	Value               interface{} `yaml:"value,omitempty"`
-	Provider            string      `yaml:"provider,omitempty"`
-	Project             string      `yaml:"project,omitempty"`
+	EnvironmentVariable string `yaml:"environment-variable,omitempty"`
+	SecretKey           string `yaml:"secret-key,omitempty"`
+	SecretPath          string `yaml:"secret-path,omitempty"`
+	Value               any    `yaml:"value,omitempty"`
+	Provider            string `yaml:"provider,omitempty"`
+	Project             string `yaml:"project,omitempty"`
 }
 
 // UnmarshalYAML implements custom YAML unmarshaling for EnvItem
@@ -40,11 +83,11 @@ type EnvItem struct {
 func (e *EnvItem) UnmarshalYAML(value *yaml.Node) error {
 	// For map syntax, the env var name is the map key; object holds fields only
 	var temp struct {
-		SecretKey  string      `yaml:"secret-key,omitempty"`
-		SecretPath string      `yaml:"secret-path,omitempty"`
-		Value      interface{} `yaml:"value,omitempty"`
-		Provider   string      `yaml:"provider,omitempty"`
-		Project    string      `yaml:"project,omitempty"`
+		SecretKey  string `yaml:"secret-key,omitempty"`
+		SecretPath string `yaml:"secret-path,omitempty"`
+		Value      any    `yaml:"value,omitempty"`
+		Provider   string `yaml:"provider,omitempty"`
+		Project    string `yaml:"project,omitempty"`
 	}
 	if err := value.Decode(&temp); err != nil {
 		return err
@@ -170,8 +213,13 @@ func processValueInterpolations(config *KubaConfig) error {
 							env.Env[name] = tmp
 							changed = true
 						}
-						// Store the value in resolved vars
+						// Store the value in resolved vars and trigger another iteration
+						// only if this introduces a new mapping or changes an existing one.
+						prev, exists := resolvedVars[name]
 						resolvedVars[name] = strValue
+						if !exists || prev != strValue {
+							changed = true
+						}
 					}
 				}
 			}
@@ -182,10 +230,105 @@ func processValueInterpolations(config *KubaConfig) error {
 			}
 		}
 
+		// After env item values are processed, interpolate other string fields that may reference them
+		// Build a map of resolved variables from the now-updated env values
+		resolvedVars = make(map[string]string)
+		for name, envItem := range env.Env {
+			if envItem.Value != nil {
+				resolvedVars[name] = fmt.Sprintf("%v", envItem.Value)
+			}
+		}
+
+		// Interpolate environment-level project field
+		if env.Project != "" && strings.Contains(env.Project, "${") {
+			interpolated := interpolateEnvVars(env.Project, resolvedVars)
+			if interpolated != env.Project {
+				env.Project = interpolated
+			}
+		}
+
+		// Interpolate item-level fields that can be strings
+		for name, envItem := range env.Env {
+			// secret-key
+			if envItem.SecretKey != "" && strings.Contains(envItem.SecretKey, "${") {
+				envItem.SecretKey = interpolateEnvVars(envItem.SecretKey, resolvedVars)
+			}
+			// secret-path
+			if envItem.SecretPath != "" && strings.Contains(envItem.SecretPath, "${") {
+				envItem.SecretPath = interpolateEnvVars(envItem.SecretPath, resolvedVars)
+			}
+			// project (item-level)
+			if envItem.Project != "" && strings.Contains(envItem.Project, "${") {
+				envItem.Project = interpolateEnvVars(envItem.Project, resolvedVars)
+			}
+			env.Env[name] = envItem
+		}
+
 		// Update the environment in the config
 		config.Environments[envName] = env
 	}
 
+	return nil
+}
+
+// resolveInheritance merges env variables from inherited environments into each environment.
+// Inheritance is processed in order; later entries in "inherits" override earlier ones only
+// if the current environment does not provide an explicit override. Current environment values
+// always take precedence over inherited ones. Cycles are detected and reported.
+func resolveInheritance(config *KubaConfig) error {
+	// Memoize resolved env maps to avoid re-computation
+	resolved := make(map[string]map[string]EnvItem)
+	resolving := make(map[string]bool)
+
+	var resolveEnv func(name string) (map[string]EnvItem, error)
+	resolveEnv = func(name string) (map[string]EnvItem, error) {
+		if env, ok := resolved[name]; ok {
+			return env, nil
+		}
+		if resolving[name] {
+			return nil, fmt.Errorf("inheritance cycle detected involving environment '%s'", name)
+		}
+		base, ok := config.Environments[name]
+		if !ok {
+			return nil, fmt.Errorf("inherits references unknown environment '%s'", name)
+		}
+		resolving[name] = true
+
+		// Start with an empty map, merge inherited in order
+		merged := make(map[string]EnvItem)
+		for _, parentName := range base.Inherits {
+			parentEnv, err := resolveEnv(parentName)
+			if err != nil {
+				return nil, err
+			}
+			// Merge from parent; do not overwrite existing keys
+			for k, v := range parentEnv {
+				if _, exists := merged[k]; !exists {
+					merged[k] = v
+				}
+			}
+		}
+
+		// Finally, overlay current environment's own variables (override parents)
+		for k, v := range base.Env {
+			merged[k] = v
+		}
+
+		resolving[name] = false
+		resolved[name] = merged
+		return merged, nil
+	}
+
+	// Resolve for all environments and write back the merged maps
+	for envName := range config.Environments {
+		merged, err := resolveEnv(envName)
+		if err != nil {
+			return err
+		}
+		env := config.Environments[envName]
+		env.Env = merged
+		config.Environments[envName] = env
+	}
 	return nil
 }
 
@@ -225,13 +368,20 @@ func LoadKubaConfig(configPath string) (*KubaConfig, error) {
 
 	logger.Debug("YAML parsed successfully", "environments_count", len(config.Environments))
 
+	// Resolve inheritance before any interpolations or validation
+	logger.Debug("Resolving environment inheritance")
+	if err := resolveInheritance(&config); err != nil {
+		logger.Debug("Failed to resolve environment inheritance", "error", err)
+		return nil, fmt.Errorf("failed to resolve inheritance: %w", err)
+	}
+	logger.Debug("Environment inheritance resolved successfully")
+
 	// Process environment variable interpolations
 	logger.Debug("Processing environment variable interpolations")
 	if err := processValueInterpolations(&config); err != nil {
 		logger.Debug("Failed to process environment variable interpolations", "error", err)
 		return nil, fmt.Errorf("failed to process environment variable interpolations: %w", err)
 	}
-
 	logger.Debug("Environment variable interpolations processed successfully")
 
 	// Validate configuration
@@ -291,9 +441,9 @@ func validateConfig(config *KubaConfig) error {
 			return fmt.Errorf("environment '%s': project is required for provider '%s'", envName, env.Provider)
 		}
 
-		// At least one env item must be provided
+		// At least one env item must be provided, possibly via inheritance
 		if len(env.Env) == 0 {
-			return fmt.Errorf("environment '%s': at least one env item is required", envName)
+			return fmt.Errorf("environment '%s': at least one env item is required (directly or via inherits)", envName)
 		}
 
 		// Validate env items

--- a/kuba.schema.json
+++ b/kuba.schema.json
@@ -11,19 +11,17 @@
         "provider": {
           "description": "The default cloud provider for this environment.",
           "type": "string",
-          "enum": [
-            "gcp",
-            "azure",
-            "aws",
-            "openbao",
-            "local"
-          ]
+          "enum": ["gcp", "azure", "aws", "openbao", "local"]
         },
         "project": {
           "description": "The default cloud project for this environment. This can be a string or an integer.",
-          "type": [
-            "string",
-            "integer"
+          "type": ["string", "integer"]
+        },
+        "inherits": {
+          "description": "One or more environment names to inherit variables from (in order).",
+          "oneOf": [
+            { "type": "string" },
+            { "type": "array", "items": { "type": "string" } }
           ]
         },
         "env": {
@@ -35,21 +33,31 @@
               "properties": {
                 "secret-key": { "type": "string" },
                 "secret-path": { "type": "string" },
-                "value": { "type": ["string","integer"] },
-                "provider": { "type": "string", "enum": ["gcp","azure","aws","openbao","local"] },
-                "project": { "type": ["string","integer"] }
+                "value": { "type": ["string", "integer"] },
+                "provider": {
+                  "type": "string",
+                  "enum": ["gcp", "azure", "aws", "openbao", "local"]
+                },
+                "project": { "type": ["string", "integer"] }
               },
-              "oneOf": [
-                { "required": [ "secret-key" ] },
-                { "required": [ "secret-path" ] },
-                { "required": [ "value" ] }
-              ],
               "allOf": [
                 {
                   "if": { "properties": { "provider": { "const": "local" } } },
                   "then": {
-                    "required": [ "value" ],
-                    "not": { "anyOf": [ { "required": ["secret-key"] }, { "required": ["secret-path"] } ] }
+                    "required": ["value"],
+                    "not": {
+                      "anyOf": [
+                        { "required": ["secret-key"] },
+                        { "required": ["secret-path"] }
+                      ]
+                    }
+                  },
+                  "else": {
+                    "oneOf": [
+                      { "required": ["secret-key"] },
+                      { "required": ["secret-path"] },
+                      { "required": ["value"] }
+                    ]
                   }
                 }
               ],
@@ -61,10 +69,7 @@
       },
       "allOf": [
         {
-          "required": [
-            "provider",
-            "env"
-          ]
+          "required": ["provider"]
         },
         {
           "if": {
@@ -77,9 +82,7 @@
             }
           },
           "then": {
-            "required": [
-              "project"
-            ]
+            "required": ["project"]
           }
         }
       ],


### PR DESCRIPTION
The user can now inherit from other env blocks.

An example looks like this:

```yaml
---
iac-base:
  # Provider "local" supports only hard-coded values via "value"
  # but we don't need secret retrieval at this point.
  # You can also just use a regular provider to retrieve secrets at this
  # point.
  provider: local
  env:
    GCP_PROJECT:
      value: "a-gcp-project-name"
    GCP_SERVICE:
      value: "my-test-service"

iac-production:
  provider: gcp
  project: 1337
  inherits:
    - iac-base
  env:
    TERRAFORM_ENVIRONMENT:
      value: "prod"
    DATADOG_API_KEY:
      secret-key: "datadog-api-key-${TERRAFORM_ENVIRONMENT}"
```