### PR TITLE
feat(dx): add show command

### DIFF
--- a/cmd/kuba/show.go
+++ b/cmd/kuba/show.go
@@ -1,0 +1,152 @@
+package kuba
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/mistweaverco/kuba/internal/config"
+	"github.com/mistweaverco/kuba/internal/lib/log"
+	"github.com/mistweaverco/kuba/internal/lib/secrets"
+	"github.com/spf13/cobra"
+)
+
+var (
+	showEnvironment string
+	showConfigFile  string
+	showSensitive   bool
+)
+
+var showCmd = &cobra.Command{
+	Use:   "show",
+	Short: "Show environment variables from kuba.yaml",
+	Long: `Show environment variables from kuba.yaml configuration.
+
+This command displays environment variables in KEY=value format, similar to
+'kuba run --contain -- env', but only includes values from kuba.yaml.
+
+You can filter the output by providing one or more pattern arguments. Patterns
+are case-insensitive and support '*' as a wildcard character.
+
+Examples:
+  kuba show                    # Show all variables from default environment
+  kuba show db_password        # Show only DB_PASSWORD
+  kuba show --env staging db*  # Show all variables starting with DB from staging
+  kuba show db*p*              # Show variables matching DB*P* pattern
+  kuba show db_* gcp_*         # Show variables starting with DB_ or GCP_
+  kuba show --sensitive        # Show all variables with redacted values`,
+	Args: cobra.ArbitraryArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runShowCommand(args)
+	},
+}
+
+func init() {
+	showCmd.Flags().StringVarP(&showEnvironment, "env", "e", "default", "Environment to use (default: default)")
+	showCmd.Flags().StringVarP(&showConfigFile, "config", "c", "", "Path to kuba.yaml configuration file")
+	showCmd.Flags().BoolVar(&showSensitive, "sensitive", false, "Redact sensitive values")
+	rootCmd.AddCommand(showCmd)
+}
+
+func runShowCommand(patterns []string) error {
+	logger := log.NewLogger()
+
+	// Find configuration file if not specified
+	if showConfigFile == "" {
+		var err error
+		logger.Debug("No config file specified, searching for kuba.yaml")
+		showConfigFile, err = config.FindConfigFile()
+		if err != nil {
+			return fmt.Errorf("failed to find configuration file: %w", err)
+		}
+		logger.Debug("Found configuration file", "path", showConfigFile)
+	} else {
+		logger.Debug("Using specified configuration file", "path", showConfigFile)
+	}
+
+	// Load configuration
+	logger.Debug("Loading configuration from file")
+	kubaConfig, err := config.LoadKubaConfig(showConfigFile)
+	if err != nil {
+		return fmt.Errorf("failed to load configuration: %w", err)
+	}
+	logger.Debug("Configuration loaded successfully")
+
+	// Get environment configuration
+	logger.Debug("Getting environment configuration", "environment", showEnvironment)
+	env, err := kubaConfig.GetEnvironment(showEnvironment)
+	if err != nil {
+		return fmt.Errorf("failed to get environment '%s': %w", showEnvironment, err)
+	}
+	logger.Debug("Environment configuration retrieved", "environment", showEnvironment, "provider", env.Provider, "env_count", len(env.Env))
+
+	// Create secrets manager factory
+	logger.Debug("Creating secrets manager factory")
+	factory := secrets.NewSecretManagerFactory()
+
+	// Get secrets for the environment
+	ctx := context.Background()
+	logger.Debug("Fetching secrets from cloud providers")
+	secrets, err := factory.GetSecretsForEnvironmentWithCache(ctx, env, showConfigFile, showEnvironment)
+	if err != nil {
+		return fmt.Errorf("failed to get secrets: %w", err)
+	}
+	logger.Debug("Secrets retrieved successfully", "count", len(secrets))
+
+	// Filter secrets based on patterns
+	filteredSecrets := filterSecrets(secrets, patterns)
+	logger.Debug("Filtered secrets", "original_count", len(secrets), "filtered_count", len(filteredSecrets))
+
+	// Display secrets
+	for key, value := range filteredSecrets {
+		displayValue := value
+		if showSensitive {
+			displayValue = maskSecret(value)
+		}
+		fmt.Printf("%s=%s\n", key, displayValue)
+	}
+
+	return nil
+}
+
+// filterSecrets filters a map of secrets based on provided patterns
+// Patterns are case-insensitive and support '*' as a wildcard
+// If no patterns are provided, all secrets are returned
+func filterSecrets(secrets map[string]string, patterns []string) map[string]string {
+	if len(patterns) == 0 {
+		return secrets
+	}
+
+	// Convert patterns to regex patterns
+	regexPatterns := make([]*regexp.Regexp, 0, len(patterns))
+	for _, pattern := range patterns {
+		// Convert wildcard pattern to regex
+		// Escape special regex characters except *
+		escaped := regexp.QuoteMeta(pattern)
+		// Replace escaped \* with .* for wildcard matching
+		escaped = strings.ReplaceAll(escaped, "\\*", ".*")
+		// Make it case-insensitive by adding (?i) prefix
+		regexPattern := "(?i)^" + escaped + "$"
+		re, err := regexp.Compile(regexPattern)
+		if err != nil {
+			// If pattern is invalid, skip it
+			continue
+		}
+		regexPatterns = append(regexPatterns, re)
+	}
+
+	// Filter secrets
+	filtered := make(map[string]string)
+	for key, value := range secrets {
+		// Check if key matches any pattern
+		for _, re := range regexPatterns {
+			if re.MatchString(key) {
+				filtered[key] = value
+				break // Match found, no need to check other patterns
+			}
+		}
+	}
+
+	return filtered
+}


### PR DESCRIPTION
`kuba show` mimics what `kuba run -- env` does on Linux / Mac currently, with the exception that it only includes the values from the `kuba.yaml`, so it is more like `kuba run --contain -- env`.

It can also include one or more optional arguments which can be used to only show the matching KEY=value pairs. The optional arguments should be considered case-insensitive.

The optional arguments also allow `*` to be used as a wildcard.

So e.g.

`kuba show` shows everything of the `default` environment block.

`kuba show db_password` shows only `DB_PASSWORD=value`

`kuba show --env staging "db*"` shows all key-value pairs starting with `DB` of the staging environment block.

`kuba show "db*p*"` would display all key-value pairs of the default environment block that match `DB*P*`, e.g. `DB_PORT` and also `DB_PASSWORD`.

`kuba show "db_*" "gcp_*"` shows all key-value pairs of the default environment block that either start with `GCP_` or `DB_`.

There should is also an optional flag `--sensitive` which will cause the values to be redacted,
similar to what is done when one uses the `kuba cache` commands.