### PR TITLE
fix(cli): remove commands registered twice

### DIFF
--- a/cmd/kuba/init.go
+++ b/cmd/kuba/init.go
@@ -22,3 +22,7 @@ var initCmd = &cobra.Command{
 		}
 	},
 }
+
+func init() {
+	rootCmd.AddCommand(initCmd)
+}

--- a/cmd/kuba/kuba.go
+++ b/cmd/kuba/kuba.go
@@ -40,12 +40,6 @@ func Execute() {
 }
 
 func init() {
-	rootCmd.AddCommand(versionCmd)
-	rootCmd.AddCommand(initCmd)
-	rootCmd.AddCommand(updateCmd)
-	rootCmd.AddCommand(cacheCmd)
-	rootCmd.AddCommand(configCmd)
-	rootCmd.PersistentFlags().BoolVar(&cfg.Flags.Version, "version", false, "Kuba version")
 	rootCmd.PersistentFlags().BoolVarP(&cfg.Flags.Debug, "debug", "d", false, "Enable debug mode for verbose logging")
 }
 

--- a/cmd/kuba/update.go
+++ b/cmd/kuba/update.go
@@ -20,7 +20,7 @@ var updateCmd = &cobra.Command{
 	Use:   "update",
 	Short: "Update kuba to the latest version",
 	Long: `Check if a newer version of kuba is available and update to it if found.
-	
+
 This command will:
 1. Check the current version against the latest GitHub release
 2. If a newer version is available, download it
@@ -328,4 +328,8 @@ func runUpdate() error {
 	fmt.Printf("Backup saved as: %s\n", backupPath)
 
 	return nil
+}
+
+func init() {
+	rootCmd.AddCommand(updateCmd)
 }

--- a/cmd/kuba/version.go
+++ b/cmd/kuba/version.go
@@ -15,3 +15,8 @@ var versionCmd = &cobra.Command{
 		fmt.Println(version.VERSION)
 	},
 }
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+	rootCmd.PersistentFlags().BoolVar(&cfg.Flags.Version, "version", false, "Kuba version")
+}

--- a/internal/lib/secrets/auth.go
+++ b/internal/lib/secrets/auth.go
@@ -259,10 +259,10 @@ func TestOpenBaoAuthorization(ctx context.Context, projectID string) (*Authoriza
 // TestLocalAuthorization tests local provider (always succeeds, no auth needed)
 func TestLocalAuthorization(ctx context.Context, projectID string) (*AuthorizationTestResult, error) {
 	result := &AuthorizationTestResult{
-		Provider:       "local",
-		ProjectID:      projectID,
-		Authenticated:  true,
-		HasPermissions: true,
+		Provider:        "local",
+		ProjectID:       projectID,
+		Authenticated:   true,
+		HasPermissions:  true,
 		CredentialsInfo: "Local provider uses environment variables - no authentication required.",
 	}
 	return result, nil


### PR DESCRIPTION
Also fix formatting in auth.go - which is used in the "test" command.